### PR TITLE
play: use cloudfront cookie behavior instead of download tokens

### DIFF
--- a/src/dlsite_async/play/api.py
+++ b/src/dlsite_async/play/api.py
@@ -37,7 +37,7 @@ class PlayAPI(BaseAPI["PlayAPI"]):
         Returns:
             A new download token.
         """
-        url = "https://play.dlsite.com/api/download_token"
+        url = "https://play.dl.dlsite.com/api/download/sign/cookie"
         async with self.get(url, params={"workno": workno}) as response:
             return DownloadToken.from_json(await response.json())
 
@@ -51,7 +51,7 @@ class PlayAPI(BaseAPI["PlayAPI"]):
             A new zip tree.
         """
         url = f"{token.url}ziptree.json"
-        async with self.get(url, params=token.params) as response:
+        async with self.get(url) as response:
             return ZipTree.from_json(await response.json())
 
     async def download_playfile(
@@ -91,9 +91,7 @@ class PlayAPI(BaseAPI["PlayAPI"]):
             dest.parent.mkdir()
         if not force and dest.exists():
             raise FileExistsError(str(dest))
-        async with self.get(
-            url, params=token.params, timeout=self._DL_TIMEOUT
-        ) as response:
+        async with self.get(url, timeout=self._DL_TIMEOUT) as response:
             try:
                 with tempfile.NamedTemporaryFile(
                     prefix=dest.name, dir=dest.parent, delete=False

--- a/src/dlsite_async/play/models.py
+++ b/src/dlsite_async/play/models.py
@@ -2,7 +2,7 @@
 from abc import ABC
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
-from datetime import datetime, timezone
+from datetime import datetime
 from functools import cached_property
 from typing import Any, Iterable, Iterator, Optional, Type, TypeVar, Union, cast
 
@@ -34,10 +34,8 @@ class _PlayModel(ABC):  # noqa: B024
 class DownloadToken(_PlayModel):
     """Play API download token."""
 
-    token: str
     expires_at: datetime
     url: str
-    workno: str
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "DownloadToken":
@@ -53,11 +51,7 @@ class DownloadToken(_PlayModel):
             DlsiteError: An error occured.
         """
         try:
-            params = data["params"]
-            data["token"] = params["token"]
-            data["expires_at"] = datetime.fromtimestamp(
-                params["expiration"], tz=timezone.utc
-            )
+            data["expires_at"] = datetime.fromisoformat(data["expires"])
             return super().from_json(data)
         except KeyError as e:  # pragma: no cover
             raise DlsiteError("Got unexpected download_token data.") from e
@@ -66,14 +60,6 @@ class DownloadToken(_PlayModel):
     def expiration(self) -> int:
         """Return expiration as POSIX timestamp."""
         return int(self.expires_at.timestamp())
-
-    @property
-    def params(self) -> dict[str, Any]:
-        """Return query params dictionary."""
-        return {
-            "expiration": self.expiration,
-            "token": self.token,
-        }
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
As of April '24 download tokens were replaced with session cookies in the Play API. This PR leaves the existing dlsite-async `download_token()` -> `ziptree()` -> `download_playfile()` workflow in place so users should not need to update their own code. `download_token()` now just acquires the required session cookie and returns the download URL + expiration for the cookie.

Should fix #136.
Should fix #139.