### PR TITLE
ci: fix broken pipx version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Upgrade pip in virtual environments
@@ -56,12 +56,12 @@ jobs:
 
       - name: Install PDM
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt pdm
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt pdm
           pdm --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
           nox --version
 
       - name: Compute pre-commit cache key
@@ -120,17 +120,17 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install --constraint=${{ github.workspace }}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Install PDM
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt pdm
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt pdm
           pdm --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
+          pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
           nox --version
 
       - name: Download coverage data


### PR DESCRIPTION
latest pipx in GHA is broken when using relative paths in pip args