### PR TITLE
Fix shooting game worktype label from SHT to STG

### DIFF
--- a/src/dlsite_async/work.py
+++ b/src/dlsite_async/work.py
@@ -41,7 +41,7 @@ class WorkType(str, Enum):
     NOVEL = "NRE"
     PUZZLE = "PZL"
     ROLE_PLAYING = "RPG"
-    SHOOTING = "SHT"
+    SHOOTING = "STG"
     SIMULATION = "SLN"
     TABLE = "TBL"
     TOOLS_ACCESSORIES = "TOL"


### PR DESCRIPTION
The worktype label for shooting games on dlsite is STG, but the interpreter in `work.py` expects SHT. This causes an error whenever you try to pull data for a shooting game. For example:

```
import asyncio
from dlsite_async import DlsiteAPI

async def f():
   async with DlsiteAPI() as api:
      return await api.get_work("RJ254840")

asyncio.run(f())
```

throws

`ValueError: 'STG' is not a valid WorkType`

The pull request modifies `work.py` to instead look for STG.