### PR TITLE
play/ebook: download voicecomic audio by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Async DLsite Play API
     HLS video segments is not supported.
 - Supports de-scrambling downloaded images (from book type works)
   - Image de-scrambling requires installation with `dlsite-async[pil]`
-- Supports downloading Comic Viewer ebook format (works with `ebook_fixed` PlayFile type)
+- Supports downloading Comic Viewer ebook formats (`ebook_fixed`, `ebook_webtoon`,
+  `voicecomic_v2` PlayFile types)
+  - For `voicecomic_v2` works, audio for each page is downloaded alongside page images.
 
 ## Requirements
 

--- a/src/dlsite_async/play/models.py
+++ b/src/dlsite_async/play/models.py
@@ -107,7 +107,7 @@ class PlayFile(_PlayModel):
 
     @property
     def is_ebook(self) -> bool:
-        return self.type in {"ebook_fixed", "ebook_webtoon"}
+        return self.type in {"ebook_fixed", "ebook_webtoon", "voicecomic_v2"}
 
     @classmethod
     def from_json(
@@ -271,18 +271,20 @@ class ViewerToken(_PlayModel):
     key_pair_id: str
     policy: str
     signature: str
-    d: str
+    d: str | None
     v: str
 
     @property
     def params(self) -> dict[str, Any]:
-        return {
+        p = {
             "Policy": self.policy,
             "Signature": self.signature,
             "Key-Pair-Id": self.key_pair_id,
-            "d": self.d,
-            "v": self.v,
         }
+        if self.d is not None:
+            p["d"] = self.d
+        p["v"] = self.v
+        return p
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "ViewerToken":
@@ -303,7 +305,7 @@ class ViewerToken(_PlayModel):
             data["key_pair_id"] = parameters["Key-Pair-Id"]
             data["policy"] = parameters["Policy"]
             data["signature"] = parameters["Signature"]
-            data["d"] = parameters["d"]
+            data["d"] = parameters.get("d")
             return super().from_json(data)
         except KeyError as e:  # pragma: no cover
             raise DlsiteError("Got unexpected download_token data.") from e


### PR DESCRIPTION
Dlsite Play ebook downloader now downloads page audio by default if it exists (i.e. for `voicecomic_v2` works). Audio download can be skipped by setting `download_page(..., audio=False)`.

Closes #184.