### PR TITLE
work: expose masked work and series titles

### DIFF
--- a/src/dlsite_async/_scraper.py
+++ b/src/dlsite_async/_scraper.py
@@ -136,7 +136,7 @@ _parsers = [
     _ListRowParser("voice_actor", ("声優", "Voice Actor")),
     _ListRowParser("writer", ("作家", "Writer")),
     _TextRowParser("file_size", ("ファイル容量", "File size")),
-    _TextRowParser("series", ("シリーズ名", "Series", "Series name")),
+    _TextRowParser("title_name_masked", ("シリーズ名", "Series", "Series name")),
 ]
 
 

--- a/src/dlsite_async/work.py
+++ b/src/dlsite_async/work.py
@@ -86,6 +86,7 @@ class Work:
     page_count: Optional[int] = None
     description: Optional[str] = None
     sample_images: Optional[list[str]] = None
+    work_name_masked: Optional[str] = None
 
     @classmethod
     def from_dict(cls, d: Mapping[str, Any]) -> "Work":

--- a/src/dlsite_async/work.py
+++ b/src/dlsite_async/work.py
@@ -70,7 +70,6 @@ class Work:
     book_type: Optional[BookType] = None
     announce_date: Optional[datetime] = None
     modified_date: Optional[datetime] = None
-    series: Optional[str] = None
     scenario: Optional[list[str]] = None
     illustration: Optional[list[str]] = None
     voice_actor: Optional[list[str]] = None
@@ -87,6 +86,8 @@ class Work:
     description: Optional[str] = None
     sample_images: Optional[list[str]] = None
     work_name_masked: Optional[str] = None
+    title_name: Optional[str] = None
+    title_name_masked: Optional[str] = None
 
     @classmethod
     def from_dict(cls, d: Mapping[str, Any]) -> "Work":
@@ -98,3 +99,13 @@ class Work:
     def release_date(self) -> Optional[datetime]:
         """Release date."""
         return self.regist_date
+
+    @property
+    def series(self) -> Optional[str]:
+        """Series name.
+
+        Set for backwards compatibility.
+        """
+        if self.title_name_masked is not None:
+            return self.title_name_masked
+        return self.title_name

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,7 +42,7 @@ _TEST_HTML_WORK = replace(
     page_count=123,
     circle="Test Circle",
     voice_actor=["Test Seiyuu 1", "Test Seiyuu 2"],
-    series="Test Series",
+    title_name_masked="Test Series",
 )
 _WORK_TEST_HTML = r"""
 <html>


### PR DESCRIPTION
- Exposes `Work.work_name_masked`, `Work.title_name` (unmasked series name), `Work.title_name_masked` (masked series name) from the product API
    - Masked names match what is visible in the web UI (where certain terms may be censored with `◯` or `*`)
    - `Work.work_name` is unchanged (and has always contained the unmasked name from the product API)
- `Work.series` is now equivalent to `Work.title_name_masked` for compatibility with prior `dlsite-async` releases
    - The masked version is used since previously `Work.series` was scraped via the web UI HTML