### PR TITLE
fix: assign crop result in descramble function

### DIFF
--- a/src/dlsite_async/play/scramble.py
+++ b/src/dlsite_async/play/scramble.py
@@ -110,5 +110,5 @@ def descramble(path: Union[str, Path], playfile: PlayFile) -> None:
         new_im.paste(tile, (x * tile_w, y * tile_w))
     # crop to actual image dimensions
     # (scrambled image is padded to align to 128 pixel tile boundary)
-    new_im.crop((0, 0, width, height))
+    new_im = new_im.crop((0, 0, width, height))
     new_im.save(path)

--- a/tests/play/test_scramble.py
+++ b/tests/play/test_scramble.py
@@ -7,6 +7,50 @@ from dlsite_async.play.models import PlayFile
 from dlsite_async.play.scramble import descramble
 
 
+def test_descramble_crops_to_original_size(tmp_path: Path) -> None:
+    """Image should be cropped to original dimensions after descramble.
+
+    When original image dimensions are not aligned to 128px tile boundary,
+    DLsite pads the image with white pixels. After descramble, the image
+    should be cropped back to original dimensions.
+
+    Test case:
+        - Original image: 200x160 (not divisible by 128)
+        - Padded image: 256x256 (2x2 tiles)
+        - After descramble: should be 200x160 (cropped)
+    """
+    # Create a 256x256 padded image (simulating DLsite's padding)
+    image_file = tmp_path / "test_crop.png"
+    im = Image.new("RGB", (256, 256), color=(255, 255, 255))  # White padding
+    # Fill actual content area (200x160) with red
+    content = Image.new("RGB", (200, 160), color=(255, 0, 0))
+    im.paste(content, (0, 0))
+    im.save(image_file)
+
+    playfile = PlayFile(
+        1,
+        "image",
+        {
+            "optimized": {
+                "name": "000000000000.png",
+                "length": 1,
+                "width": 200,  # Original width (before padding)
+                "height": 160,  # Original height (before padding)
+                "crypt": False,  # No scrambling for this test
+            }
+        },
+        "abc123",
+    )
+    descramble(image_file, playfile)
+
+    with Image.open(image_file) as result:
+        # Image should be cropped to original dimensions
+        assert result.size == (200, 160), f"Expected (200, 160), got {result.size}"
+        # All pixels should be red (content), no white padding
+        px = result.load()
+        assert px[199, 159] == (255, 0, 0), "Bottom-right should be red content"
+
+
 def test_descramble(tmp_path: Path) -> None:
     """Image should be descrambled.
 


### PR DESCRIPTION
 ## Problem

  The `descramble()` function in `scramble.py` does not properly crop images to their original dimensions. This results in white padding remaining in descrambled images.

  ## Cause

  `Image.crop()` returns a new image object but the result was not being assigned back to the variable.

  ```python
  # Before (buggy)
  new_im.crop((0, 0, width, height))  # Result discarded
  new_im.save(path)

  # After (fixed)
  new_im = new_im.crop((0, 0, width, height))  # Result assigned
  new_im.save(path)

  Changes

  - Fixed scramble.py line 113 to assign crop result
  - Added test test_descramble_crops_to_original_size to verify crop behavior

  Test

  python -m pytest tests/play/test_scramble.py -v