### PR TITLE
fix PlayAPI.purchases() sale/purchase timestamp

### DIFF
--- a/src/dlsite_async/play/api.py
+++ b/src/dlsite_async/play/api.py
@@ -182,7 +182,7 @@ class PlayAPI(BaseAPI["PlayAPI"]):
                 purchase, sales_date = _parse_purchase(
                     work, locale=self.locale or "ja_JP"
                 )
-                yield (purchase, sales_date or sales.get(purchase.product_id))
+                yield (purchase, sales.get(purchase.product_id) or sales_date)
 
     async def _get_product_count(self, last: int) -> tuple[int, int, int]:
         url = "https://play.dlsite.com/api/v3/content/count"


### PR DESCRIPTION
- fixes bug where `purchases()` would return the timestamp for when a work was released for sales, not when user purchased the work